### PR TITLE
Include svn command output in error message. Throw error object instead of string.

### DIFF
--- a/lib/svn-info.js
+++ b/lib/svn-info.js
@@ -53,7 +53,7 @@ module.exports.sync = function(path) {
   path = path || '.';
   var cmd = sh.exec('svn info ' + path, {silent: true});
   if(0 !== cmd.code) {
-    throw('Encountered an error trying to get svn info for ' + path);
+    throw new Error('Encountered an error trying to get svn info for ' + path + '\n' + cmd.output);
   }
   return normalizeInfo(cmd.output);
 };


### PR DESCRIPTION
Command output is handy to help with identifying (and fixing) the cause of the error. While passing an error object provides stack trace rather than just the line where the error is thrown, more info http://www.devthought.com/2011/12/22/a-string-is-not-an-error/ .

Here's a comparison of the error messages before and after the patch:
## Before

foobar/node_modules/svn-info/lib/svn-info.js:58
    throw('Encountered an error trying to get svn info for ' + path);
                                                             ^
Encountered an error trying to get svn info for foobar
## After

foobar/node_modules/svn-info/lib/svn-info.js:60
    throw new Error('Encountered an error trying to get svn info for ' + path 
          ^
Error: Encountered an error trying to get svn info for foobar
svn: E155036: Please see the 'svn upgrade' command
svn: E155036: Working copy '/foobar' is too old (format 10, created by Subversion 1.6)
    at Function.module.exports.sync (foobar/node_modules/svn-info/lib/svn-info.js:58:11)
    at Local._svn (foobar/lib/generator/local.js:48:22)
    at foobar/lib/generator/local.js:30:12
    at Array.forEach (native)
    at Local.generate (foobar/lib/generator/local.js:21:9)
    at Repoman.config (foobar/lib/repoman.js:62:11)
    at Command._config (foobar/lib/cli.js:27:17)
    at Command.<anonymous> (foobar/node_modules/bagofcli/node_modules/commander/index.js:249:8)
    at Command.EventEmitter.emit (events.js:98:17)
    at Command.parseArgs (foobar/node_modules/bagofcli/node_modules/commander/index.js:472:12)
